### PR TITLE
ticketページ、リストの追加表示への埋め込み

### DIFF
--- a/animetick-to-mastodon.user.js
+++ b/animetick-to-mastodon.user.js
@@ -6,6 +6,7 @@
 // @author       theoria
 // @match        http://animetick.net/
 // @match        http://animetick.net/anime/*
+// @match        http://animetick.net/ticket/*
 // @license      The Unlicense
 // @grant        none
 // ==/UserScript==
@@ -25,7 +26,7 @@ function mastodon_share_url(anime_id, episode_num, title, subtitle, hashtag) {
 (function() {
   'use strict';
 
-  // トップページの埋め込み
+  // トップページ、ticketページの埋め込み
   $(".detail > .button_block").each(function(i, elem) {
     if ($(elem).parent().children(".ticket_title").length) {
       var id = $(elem).parent().children(".ticket_title").attr('id');
@@ -43,7 +44,7 @@ function mastodon_share_url(anime_id, episode_num, title, subtitle, hashtag) {
     }
   });
 
-  // トップページのWatchアクション
+  // トップページ、ticketページのWatchアクション
   $('.ticket_watch').on('click', function() {
     if ($(this).not('.enable').length) {
       var cia = $(this).attr('id').split('_');
@@ -72,7 +73,7 @@ function mastodon_share_url(anime_id, episode_num, title, subtitle, hashtag) {
     }
   });
 
-  // トップのリスト追加表示への埋め込み
+  // リスト追加表示への埋め込み
   (new MutationObserver(function (MutationRecords, MutationObserver) {
     $('.detail > .twitter').each(function(i, elem) {
       if ($(elem).parent().children('.twitter').length==1) {

--- a/animetick-to-mastodon.user.js
+++ b/animetick-to-mastodon.user.js
@@ -71,4 +71,17 @@ function mastodon_share_url(anime_id, episode_num, title, subtitle, hashtag) {
       }
     }
   });
+
+  // トップのリスト追加表示への埋め込み
+  (new MutationObserver(function (MutationRecords, MutationObserver) {
+    $('.detail > .twitter').each(function(i, elem) {
+      if ($(elem).parent().children('.twitter').length==1) {
+        var id = $(elem).children(".twitter").attr('id');
+        var ary = id.split('_');
+        $(elem).parent().append(mastodon_checkbox_html(ary[1], ary[2]));
+      }
+    });
+  })).observe($('#ticket_list').get(0), {
+    childList: true,
+  });;
 })();


### PR DESCRIPTION
- 後から読み込まれるチケットにMastodonボタンが表示されない　の修正
- /ticket/* ページへの埋め込みの対応

です。